### PR TITLE
Version 2-1-0

### DIFF
--- a/src/common/appversions.ts
+++ b/src/common/appversions.ts
@@ -2,8 +2,8 @@
  * Application-level version descriptors for the About Window
  */
 
-export const applicationVersion: string = '2.0.0';
-export const copyrightYearRange: string = '2022-2023';
+export const applicationVersion: string = '2.1.0';
+export const copyrightYearRange: string = '2022-2024';
 export const uiLibrary: string = 'React 18.0.0';
 export const uiControls: string = 'Semantic UI React 2.1.3';
 export const stateManagement: string = 'MobX 6.6.2, MobX-React 7.5.3';

--- a/src/common/datastore.ts
+++ b/src/common/datastore.ts
@@ -468,6 +468,20 @@ class TradeShowData {
     this.cleanupBoothAuto(boothId);
   };
 
+  @action public updatePowerBuy = (boothId: string, pcCode: string, pbQty: number) => {
+    this.initBoothIfNeeded(boothId);
+    let convertedPBs = this.vendorsWithActions.get(boothId).powerBuys;
+    if (pbQty === 0) {
+      // Unset a PC if it was explicitly set to 0
+      convertedPBs.delete(pcCode);
+    } else if (pbQty !== undefined) {
+      let submittable: ISubmittableQty = { quantity: pbQty, submitted: false };
+      convertedPBs.set(pcCode, submittable);
+    }
+    this.vendorsWithActions.get(boothId).powerBuys = convertedPBs;
+    this.cleanupBoothAuto(boothId);
+  };
+
   @action public getGUIPowerBuys = (boothId: string|undefined): Map<string, number|undefined> => {
     let pbs = new Map<string, number|undefined>();
     this.vendorsWithActions.get(boothId)?.powerBuys.forEach((val: ISubmittableQty, key: string) => {
@@ -509,6 +523,20 @@ class TradeShowData {
         convertedPCs.set(key, submittable);
       }
     });
+    this.vendorsWithActions.get(boothId).profitCenters = convertedPCs;
+    this.cleanupBoothAuto(boothId);
+  };
+
+  @action public updateProfitCenter = (boothId: string, pcCode: string, pcQty: number) => {
+    this.initBoothIfNeeded(boothId);
+    let convertedPCs = this.vendorsWithActions.get(boothId).profitCenters;
+    if (pcQty === 0) {
+      // Unset a PC if it was explicitly set to 0
+      convertedPCs.delete(pcCode);
+    } else if (pcQty !== undefined) {
+      let submittable: ISubmittableQty = { quantity: pcQty, submitted: false };
+      convertedPCs.set(pcCode, submittable);
+    }
     this.vendorsWithActions.get(boothId).profitCenters = convertedPCs;
     this.cleanupBoothAuto(boothId);
   };

--- a/src/displays/taskdetaillist.tsx
+++ b/src/displays/taskdetaillist.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Header } from 'semantic-ui-react';
+import { Button, Header } from 'semantic-ui-react';
 
 import { inject, observer } from 'mobx-react';
 
@@ -7,11 +7,17 @@ import { IVendorStatus } from '../types/interfaces';
 import SimpleSubmittableGroup from '../widgets/simplesubmittablegroup';
 import QuestionAnswerGroup from '../widgets/questionanswergroup';
 import OpenStockGroup from '../widgets/openstockgroup';
+import BulkAddModal from '../modals/bulkaddmodal';
 
 interface TaskDetailListProps {
   hideCompleted: boolean;
   alphaSort: boolean;
   showStore?: any;
+};
+
+interface TaskDetailListState {
+  bulkModalPBShown: boolean;
+  bulkModalPCShown: boolean;
 };
 
 /*
@@ -20,7 +26,15 @@ interface TaskDetailListProps {
  * The display can be sorted by booth number or lexicographically by vendor.
  */
 @inject('showStore') @observer
-export default class TaskDetailList extends React.Component<TaskDetailListProps> {
+export default class TaskDetailList extends React.Component<TaskDetailListProps, TaskDetailListState> {
+  constructor(props: TaskDetailListProps, state: TaskDetailListState) {
+    super(props, state);
+    this.state ={
+      bulkModalPBShown: false,
+      bulkModalPCShown: false,
+    };
+  }
+
   render() {
     const {
       hideCompleted,
@@ -108,8 +122,18 @@ export default class TaskDetailList extends React.Component<TaskDetailListProps>
 
     return (
       <div className='tabInnerLayout'>
+        <BulkAddModal open={this.state.bulkModalPBShown} closeHandler={this.showBulkModalPB} type='PB' />
+        <BulkAddModal open={this.state.bulkModalPCShown} closeHandler={this.showBulkModalPC} type='PC' />
         <div className="BCI_vendoritems">
-          <div className='BCI_taskgroupitem'>
+        <div className='BCI_taskgroupitem' style={{textAlign: 'left'}}>
+          <Button primary button name='PB' key='PBbtn' onClick={this.triggerBulkModalPB}>
+            Bulk-Add Power Buys
+          </Button>
+          <Button primary button name='PC' key='PCbtn' onClick={this.triggerBulkModalPC}>
+            Bulk-Add Profit Centers
+          </Button>
+        </div>
+        <div className='BCI_taskgroupitem'>
             <Header as='h2' dividing textAlign='left' color='orange'>Questions</Header>
             {questionRows}
           </div>
@@ -129,4 +153,24 @@ export default class TaskDetailList extends React.Component<TaskDetailListProps>
       </div>
     );
   }
+
+  private triggerBulkModalPC = () => {
+    this.showBulkModalPC(true);
+  };
+
+  private showBulkModalPC = (shown: boolean) => {
+    this.setState({
+      bulkModalPCShown: shown,
+    });
+  };
+
+  private triggerBulkModalPB = () => {
+    this.showBulkModalPB(true);
+  };
+
+  private showBulkModalPB = (shown: boolean) => {
+    this.setState({
+      bulkModalPBShown: shown,
+    });
+  };
 }

--- a/src/modals/bulkaddmodal.tsx
+++ b/src/modals/bulkaddmodal.tsx
@@ -1,0 +1,186 @@
+import React, { createRef } from 'react';
+import { ChangeEvent, SyntheticEvent } from 'react';
+import {
+  Button,
+  Form,
+  Input,
+  InputProps,
+  Message,
+  Modal,
+} from 'semantic-ui-react';
+
+import { inject, observer } from 'mobx-react';
+
+import { SimpleSubmittableType } from '../types/enums';
+
+interface BulkAddModalProps {
+  open: boolean,
+  closeHandler: (isShown: boolean) => any;
+  type: SimpleSubmittableType;
+  showStore?: any;
+};
+
+interface BulkAddModalState {
+  inBoothNum: string;
+  inItemCode: string;
+  inItemQty: number;
+  successMsg: string;
+  rejectMsg: string;
+};
+
+/*
+ * Bulk Add Task modal:
+ *
+ * Facilitates adding multiple Profit Center items across all booths.
+ */
+@inject('showStore') @observer
+export default class BulkAddModal extends React.Component<BulkAddModalProps, BulkAddModalState> {
+  private boothInputRef: React.RefObject<Input>;
+  private pcInputRef: React.RefObject<Input>;
+
+  constructor(props: BulkAddModalProps, state: BulkAddModalState) {
+    super(props, state);
+    this.state = {
+      inBoothNum: '',
+      inItemCode: '',
+      inItemQty: 1,
+      successMsg: '',
+      rejectMsg: '',
+    };
+    this.boothInputRef = createRef();
+    this.pcInputRef = createRef();
+  }
+
+  render() {
+    const headerText = this.props.type === 'PC' ? 'Profit Center' : 'Power Buy';
+    return (
+      <Modal open={this.props.open} centered={false}>
+        <Modal.Header>Bulk-Add {headerText} Items</Modal.Header>
+        <Modal.Content scrolling={true}>
+          <Form>
+            <Form.Group>
+              <Form.Field>
+                <Input style={{fontFamily: 'monospace', width: '85px'}}
+                       label={this.props.type}
+                       ref={this.boothInputRef}
+                       maxLength={3}
+                       value={this.state.inBoothNum}
+                       onChange={this.boothNumChange} />
+              </Form.Field>
+              <Form.Field>
+                <Input style={{fontFamily: 'monospace', width: '45px'}}
+                       ref={this.pcInputRef}
+                       maxLength={1}
+                       value={this.state.inItemCode}
+                       onChange={this.pcCodeChange} />
+              </Form.Field>
+              <Form.Field>
+                Qty:
+                <Input style={{fontFamily: 'monospace', width: '90px'}}
+                       value={this.state.inItemQty}
+                       onChange={this.qtyChange}
+                       type='number' min='0' max='9999' placeholder='Qty' />
+              </Form.Field>
+              <Form.Field>
+                <Button primary button onClick={this.addSameBooth}>Add (Retain Booth)</Button>
+                <Button primary button onClick={this.addDiffBooth}>Add (Different Booth)</Button>
+              </Form.Field>
+            </Form.Group>
+          </Form>
+          {this.state.successMsg
+            ? <Message success>{this.state.successMsg}</Message>
+            : null
+          }
+          {this.state.rejectMsg
+            ? <Message negative>{this.state.rejectMsg}</Message>
+            : null
+          }
+        </Modal.Content>
+        <Modal.Actions>
+          <Button basic color='grey' onClick={this.modalCloseOps}>Close</Button>
+        </Modal.Actions>
+      </Modal>
+    );
+  }
+
+  private boothNumChange = (e: SyntheticEvent, data: InputProps) => {
+    this.setState({ inBoothNum: data.value });
+  };
+
+  private pcCodeChange = (e: SyntheticEvent, data: InputProps) => {
+    const upperified = data.value.toUpperCase();
+    this.setState({ inItemCode: upperified });
+  };
+
+  private qtyChange = (e: ChangeEvent<HTMLInputElement>, data: InputProps) => {
+    this.setState({ inItemQty: data.value });
+  };
+
+  private addSameBooth = () => {
+    if (this.updatePCList()) {
+      this.setState({
+        inItemCode: '',
+        inItemQty: 1,
+      });
+      this.pcInputRef.current?.focus();
+    } else {
+      this.boothInputRef.current?.focus();
+    }
+  };
+
+  private addDiffBooth = () => {
+    if (this.updatePCList()) {
+      this.setState({
+        inBoothNum: '',
+        inItemCode: '',
+        inItemQty: 1,
+      });
+    }
+    this.boothInputRef.current?.focus();
+  };
+
+  private updatePCList = (): boolean => {
+    const boothNum = this.state.inBoothNum;
+    const booth = this.props.showStore.boothVendors.get(boothNum);
+    if (!booth) {
+      this.setState({
+        successMsg: '',
+        rejectMsg: `Requested Booth (${boothNum}) does not exist or is not a vendor booth number.`,
+      });
+      return false;
+    }
+    const itemCode = this.state.inItemCode;
+    if (itemCode.length !== 1 || !itemCode.match(/[A-Z]/)) {
+      this.setState({
+        successMsg: '',
+        rejectMsg: `Invalid ${this.props.type} Code specified (${itemCode}), must be [A-Z].`,
+      });
+      return false;
+    }
+    if (this.props.type === 'PC') {
+      this.props.showStore.updateProfitCenter(boothNum, itemCode, +this.state.inItemQty);
+    } else if (this.props.type === 'PB') {
+      this.props.showStore.updatePowerBuy(boothNum, itemCode, +this.state.inItemQty);
+    } else {
+      this.setState({
+        successMsg: "",
+        rejectMsg: "Tried to add something that wasn't a Power Buy or Profit Center",
+      });
+      return false;
+    }
+    this.setState({
+      successMsg: `Updated ${this.props.type}-${boothNum}${itemCode} with quantity ${this.state.inItemQty}`,
+      rejectMsg: '',
+    });
+    return true;
+  };
+
+  private modalCloseOps = () => {
+    this.setState({
+      inBoothNum: '',
+      inItemCode: '',
+      inItemQty: 1,
+    });
+    this.props.closeHandler(false);
+  };
+}

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -24,5 +24,7 @@ export enum DataLoad {
  * Task Types
  */
 export enum TaskType {
-  
+
 };
+
+export type SimpleSubmittableType = 'PC' | 'PB';

--- a/utils/csvOpenStockToVendorBooth.py
+++ b/utils/csvOpenStockToVendorBooth.py
@@ -38,8 +38,8 @@ def parseCSVVendors(argv):
 
             # Build an internal structure for the vendor data
             for row in csvVendors:
-                booth_num = row[22]
-                vendor = row[12]
+                booth_num = row[24]
+                vendor = row[14]
                 try:
                     vendors[booth_num].add(vendor)
                 except KeyError:
@@ -99,7 +99,7 @@ def parseCSVVendors(argv):
                     continue
                 if len(vendor_json['vendors'][booth_num]['vendors']) > 1:
                     print(f"\nBOOTH {booth_num} CONTAINS MULTIPLE VENDORS:\n{vendor_json['vendors'][booth_num]['vendors']}")
-                    input_name = input(f'ENTER WHAT TO NAME BOOTH NUMBER {booth_num} > ')
+                    input_name = input(f"PRESS ENTER TO ACCEPT '{default_name}' OR SPECIFY A NEW NAME HERE > ")
                     if input_name == "":
                         booth_name = default_name
                     else:


### PR DESCRIPTION
Updated Python import utility to adapt to differences in show book CSV export as of Fall 2024 show.

Adds a modal that can bulk-add Profit Center and Power Buy items without having to manually instantiate vendors (this is a common pre-show action to do, unlike vendor visits and Open Stock forms which are typically added as you go).